### PR TITLE
Add dependency-aware redraw to drawing demo

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,7 +7,7 @@ const colors = [
 ];
 let colorIndex = 0;
 const labelStyles = {};
-// 描画した要素を保持する配列
+// 描画した要素とそのパラメータを保持する配列
 const elements = [];
 const controls = document.getElementById('elementControls');
 
@@ -40,13 +40,13 @@ function drawLine(x1, y1, x2, y2, label) {
   ctx.stroke();
 }
 
-function addPoint(x, y, label) {
-  elements.push({ type: 'point', x, y, label });
+function addPoint(x, y, label, params) {
+  elements.push({ type: 'point', x, y, label, params });
   drawPoint(x, y, label);
 }
 
-function addLine(x1, y1, x2, y2, label) {
-  elements.push({ type: 'line', x1, y1, x2, y2, label });
+function addLine(x1, y1, x2, y2, label, params) {
+  elements.push({ type: 'line', x1, y1, x2, y2, label, params });
   drawLine(x1, y1, x2, y2, label);
 }
 
@@ -59,6 +59,47 @@ function redraw() {
       drawLine(el.x1, el.y1, el.x2, el.y2, el.label);
     }
   }
+}
+
+function recomputeAll() {
+  currentX = canvas.width / 2;
+  currentY = canvas.height / 2;
+  currentAngle = 0;
+  for (const el of elements) {
+    if (el.type === 'point') {
+      if (el.params.mode === 'abs') {
+        el.x = el.params.x;
+        el.y = el.params.y;
+      } else if (el.params.mode === 'rel') {
+        el.x = currentX + el.params.dx;
+        el.y = currentY + el.params.dy;
+      }
+      currentX = el.x;
+      currentY = el.y;
+    } else if (el.type === 'line') {
+      if (el.params.overrideStartX !== undefined) {
+        currentX = el.params.overrideStartX;
+        currentY = el.params.overrideStartY;
+      }
+      el.x1 = currentX;
+      el.y1 = currentY;
+      let angle;
+      if (el.params.angleMode === 'abs') {
+        angle = el.params.angle;
+      } else {
+        angle = currentAngle + el.params.angle;
+      }
+      const rad = (angle * Math.PI) / 180;
+      el.x2 = el.x1 + el.params.length * Math.cos(rad);
+      el.y2 = el.y1 + el.params.length * Math.sin(rad);
+      el.angle = angle;
+      currentAngle = angle;
+      currentX = el.x2;
+      currentY = el.y2;
+    }
+  }
+  redraw();
+  updateControls();
 }
 
 function updateControls() {
@@ -123,22 +164,24 @@ function updateControls() {
 function editPoint(index, x, y) {
   const el = elements[index];
   if (el && el.type === 'point') {
-    el.x = x;
-    el.y = y;
-    redraw();
-    updateControls();
+    el.params = { mode: 'abs', x, y };
+    recomputeAll();
   }
 }
 
 function editLine(index, x1, y1, x2, y2) {
   const el = elements[index];
   if (el && el.type === 'line') {
-    el.x1 = x1;
-    el.y1 = y1;
-    el.x2 = x2;
-    el.y2 = y2;
-    redraw();
-    updateControls();
+    const dx = x2 - x1;
+    const dy = y2 - y1;
+    el.params = {
+      length: Math.hypot(dx, dy),
+      angleMode: 'abs',
+      angle: (Math.atan2(dy, dx) * 180) / Math.PI,
+      overrideStartX: x1,
+      overrideStartY: y1,
+    };
+    recomputeAll();
   }
 }
 
@@ -185,33 +228,63 @@ function runScript(text) {
       }
     } else if (cmd === 'point') {
       const label = parts[1] || '';
+      let params;
       if (parts[2] === 'abs') {
-        currentX = parseFloat(parts[3]) || 0;
-        currentY = parseFloat(parts[4]) || 0;
+        params = {
+          mode: 'abs',
+          x: parseFloat(parts[3]) || 0,
+          y: parseFloat(parts[4]) || 0,
+        };
       } else if (parts[2] === 'rel') {
-        currentX += parseFloat(parts[3]) || 0;
-        currentY += parseFloat(parts[4]) || 0;
+        params = {
+          mode: 'rel',
+          dx: parseFloat(parts[3]) || 0,
+          dy: parseFloat(parts[4]) || 0,
+        };
+      } else {
+        params = { mode: 'abs', x: currentX, y: currentY };
       }
-      addPoint(currentX, currentY, label);
+
+      if (params.mode === 'abs') {
+        currentX = params.x;
+        currentY = params.y;
+      } else {
+        currentX += params.dx;
+        currentY += params.dy;
+      }
+
+      addPoint(currentX, currentY, label, params);
       i++;
     } else if (cmd === 'line') {
       const label = parts[1] || '';
       const length = parseFloat(parts[2]) || 0;
-      let angle;
+      let angleMode = 'abs';
+      let angleVal;
       if (parts[3] === 'abs') {
-        angle = parseFloat(parts[4]) || 0;
+        angleMode = 'abs';
+        angleVal = parseFloat(parts[4]) || 0;
       } else if (parts[3] === 'rel') {
-        angle = currentAngle + (parseFloat(parts[4]) || 0);
+        angleMode = 'rel';
+        angleVal = parseFloat(parts[4]) || 0;
       } else {
-        angle = parseFloat(parts[3]) || 0;
+        angleMode = 'abs';
+        angleVal = parseFloat(parts[3]) || 0;
       }
-      currentAngle = angle;
-      const rad = (angle * Math.PI) / 180;
-      const newX = currentX + length * Math.cos(rad);
-      const newY = currentY + length * Math.sin(rad);
-      addLine(currentX, currentY, newX, newY, label);
+
+      const startX = currentX;
+      const startY = currentY;
+      const actualAngle =
+        angleMode === 'rel' ? currentAngle + angleVal : angleVal;
+      const rad = (actualAngle * Math.PI) / 180;
+      const newX = startX + length * Math.cos(rad);
+      const newY = startY + length * Math.sin(rad);
+
+      currentAngle = actualAngle;
       currentX = newX;
       currentY = newY;
+
+      const params = { length, angleMode, angle: angleVal };
+      addLine(startX, startY, newX, newY, label, params);
       i++;
     } else {
       i++;


### PR DESCRIPTION
## Summary
- store parameters for points and lines so we can recompute them
- add `recomputeAll` to rebuild geometry from stored parameters
- update edit functions to change parameters and trigger recomputation
- parse script commands into parameterized elements

## Testing
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_e_683fdbc861e0832baeb8d76a8e25c28e